### PR TITLE
Fix MongoDB property rename for Spring Boot 4

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 server.port=8081
 
-spring.data.mongodb.uri=mongodb://${MONGO_USR}:${MONGO_PWD}@mongo:27017/paymentevents?authSource=admin
-spring.data.mongodb.database=paymentevents
+spring.mongodb.uri=mongodb://${MONGO_USR}:${MONGO_PWD}@mongo:27017/paymentevents?authSource=admin
+spring.mongodb.database=paymentevents


### PR DESCRIPTION
## Summary
- Rename `spring.data.mongodb.uri` → `spring.mongodb.uri` and `spring.data.mongodb.database` → `spring.mongodb.database`
- Spring Boot 4 moved connection-level MongoDB properties out of the `spring.data.mongodb` namespace. The old keys are silently ignored, so the driver was falling back to the `localhost:27017` default — breaking the deployed app.

## Test plan
- [ ] Rebuild image and redeploy
- [ ] Verify MongoDB connects to the `mongo` service, not `localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)