### PR TITLE
Gate Docker push on successful CI run

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,12 +2,15 @@
 name: Build and Push Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "CI" ]
+    types: [ completed ]
     branches: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     env:
       DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/payment-notifications
@@ -15,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -32,7 +37,7 @@ jobs:
           push: true
           tags: |
             ${{ env.DOCKER_IMAGE }}:latest
-            ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
+            ${{ env.DOCKER_IMAGE }}:${{ github.event.workflow_run.head_sha }}
 
       - name: Done
         run: echo "Image $DOCKER_IMAGE pushed successfully."


### PR DESCRIPTION
## Summary
- Switch docker workflow from `push` trigger to `workflow_run` keyed on CI completion, so images only publish when tests pass.
- Gate the job with `if: github.event.workflow_run.conclusion == 'success'` (workflow_run fires on any completion).
- Pin checkout and image tag to `workflow_run.head_sha` so the pushed image matches the exact commit CI verified.

## Test plan
- [ ] After merge, confirm CI and Docker no longer run concurrently on main
- [ ] Confirm docker workflow is skipped when CI fails
- [ ] Confirm image tag matches the tested commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)