### PR TITLE
Fix Dockerfile native build and validate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
           name: test-results
           path: build/reports/tests/
 
-  native:
-    name: Native compile (smoke)
+  docker:
+    name: Docker native build (smoke)
     runs-on: ubuntu-latest
     needs: test
 
@@ -49,13 +49,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up GraalVM 21
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '21'
-          distribution: 'graalvm-community'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache: 'gradle'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Native compile
-        run: ./gradlew nativeCompile
+      - name: Build native Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          tags: payment-notifications:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify binary exists in image
+        run: docker run --rm --entrypoint /bin/sh payment-notifications:ci -c 'test -x /app/payment-notifications'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # --- Stage 1: GraalVM native build ---
 FROM ghcr.io/graalvm/native-image-community:21 AS builder
 
+RUN microdnf install -y findutils && microdnf clean all
+
 WORKDIR /app
 COPY . .
 


### PR DESCRIPTION
## Summary
- The GraalVM native-image-community base image is missing `xargs` (which `./gradlew` needs), causing the post-merge Docker push in #34 to fail with `xargs is not available`. Install `findutils` in the builder stage.
- Replace the CI `native` job (which ran `nativeCompile` directly on the runner) with a `docker` job that builds the actual Dockerfile. This way image-specific breakage is caught at PR time, not after merge.
- Adds GitHub Actions cache for Docker layers so subsequent CI runs are faster.

## Test plan
- [ ] CI `Docker native build (smoke)` job passes
- [ ] On merge, `docker.yml` successfully builds and pushes the image to Docker Hub
- [ ] Pull `tedtedted/payment-notifications:latest`, run `docker compose up`, verify `POST /adyen/events` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)